### PR TITLE
Version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ plugins: [
 
 ### Transparency
 
-So you want a transparent terminal huh? Can't say I blame you. This theme allows you to customize the background transparency by setting a value in your `~/.hyper.js` config. Just create a property called `transparentBgAlpha` in the `config` object and give it a value. This value will be passed into the background color in the theme as the `a` portion of the `rgba`. So for example, if you want your terminal to have 70% alpha, this is what you'd do:
+So you want a transparent terminal huh? Can't say I blame you. This theme allows you to customize the background transparency by setting a value in your `~/.hyper.js` config. Just create a property called `transparentBgAlpha` in the `config` object and give it a value. This value will be passed into the background color in the theme as the `a` portion of the `rgba` (if you don't add this property, it defaults to 1, which is no transparency). So for example, if you want your terminal to have 70% alpha, this is what you'd do:
 
 ```js
 // ~/.hyper.js

--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ plugins: [
 ```
 3. Fully reload HyperTerm (`Cmd+Shift+R`), and tada! :tada:
 
+### Transparency
+
+So you want a transparent terminal huh? Can't say I blame you. This theme allows you to customize the background transparency by setting a value in your `~/.hyper.js` config. Just create a property called `transparentBgAlpha` in the `config` object and give it a value. This value will be passed into the background color in the theme as the `a` portion of the `rgba`. So for example, if you want your terminal to have 70% alpha, this is what you'd do:
+
+```js
+// ~/.hyper.js
+
+module.exports = {
+  config = {
+    // your normal settings and stuff
+    ...
+
+    // add this one!
+    transparentBgAlpha: 0.7,
+
+    // maybe more stuff here?
+  },
+  plugins: [
+    'hyper-electron-highlighter'
+  ],
+  localPlugins: []
+}
+```
+
 ### License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -1,23 +1,12 @@
-'use strict';
-const backgroundColor = '#212836';
-const foregroundColor = '#97a7c8';
-const cursorColor = 'rgba(72,150,255,0.8)';
-const borderColor = backgroundColor;
-const tabBg = '#1b212c';
-const tabBgDark = '#141820';
-const tabText = 'rgba(153,163,184,0.6)';
-const tabTextActive = '#d5d9e2';
-const tabActiveBorder = '#528bff';
-const dividerBg = 'rgba(151,167,200, 0.25)';
-
-const black = backgroundColor;
-const white = foregroundColor;
-const red = '#e76572';
-const green = '#6af699';
-const yellow = '#fffa9e';
-const blue = '#71b1fe';
-const magenta = '#d59df6';
-const cyan = '#4ff2f8';
+'use strict'
+const black = '#212836'
+const white = '#97a7c8'
+const red = '#e76572'
+const green = '#6af699'
+const yellow = '#fffa9e'
+const blue = '#71b1fe'
+const magenta = '#d59df6'
+const cyan = '#4ff2f8'
 
 const colors = {
   black,
@@ -36,90 +25,54 @@ const colors = {
   lightMagenta: magenta,
   lightCyan: cyan,
   lightWhite: white
-};
+}
 
-exports.decorateConfig = config => Object.assign({}, config, {
-  foregroundColor,
-  backgroundColor,
-  borderColor,
-  cursorColor,
-  colors,
-  termCSS: `
-    ${config.termCSS || ''}
-    .cursor-node {
-      mix-blend-mode: difference;
-    }
-  `,
-  css: `
-    ${config.css || ''}
-    .header_header {
-      top: 0;
-      right: 0;
-      left: 0;
-    }
-    .tabs_nav {
-      height: 41px;
-      line-height: 3em;
-    }
-    .tabs_list {
-      background-color: ${tabBg} !important;
-      border-bottom-color: ${tabBgDark} !important;
-      padding: .5em .5em 0 82px;
-      max-height: 41px;
-      margin-left: 0;
-    }
-    .tab_tab {
-      height: 3em;
-      line-height: 3em;
-    }
-    .tab_tab .tab_text {
-      border-width: 0 0 0 1px;
-      border-image: linear-gradient(${tabBg}, ${tabBgDark} 1em) 0 0 0 1 stretch;
-    }
-    .tab_textInner {
-      color: ${tabText};
-    }
-    .tab_tab.tab_active .tab_textInner {
-      color: ${tabTextActive};
-    }
-    .tab_tab.tab_active + .tab_tab .tab_text {
-      border-image: linear-gradient(transparent, transparent) 0 0 0 1 stretch;
-    }
-    .tab_first .tab_text {
-      border-width: 0;
-    }
-    .tab_tab.tab_active {
-      font-weight: 600;
-      background-color: ${backgroundColor};
-      border-color: rgba(0,0,0,.27) !important;
-      border-radius: 3px 3px 0 0;
-    }
-    .tab_tab.tab_active::before {
-      border-bottom-color: ${backgroundColor};
-      left: 1px;
-      right: 1px;
-    }
-    .tab_tab.tab_active .tab_textInner {
-      border-left: 1px solid ${tabBgDark};
-      border-right: 1px solid ${tabBgDark};
-      border-top: 1px solid ${tabBgDark};
-      border-radius: 3px 3px 0 0;
-    }
-    .tab_tab.tab_active .tab_textActive::before {
-      content: '';
-      z-index: 2;
-      pointer-events: none;
-      position: absolute;
-      top: 2px;
-      left: 1px;
-      bottom: 0px;
-      width: 2px;
-      border-top-left-radius: inherit;
-      border-radius: 3px 0;
-      background-color: ${tabActiveBorder};
-    }
-    .splitpane_divider {
-      background-color: ${dividerBg} !important;
-    }
-  `
-});
+exports.decorateConfig = config => {
+  const transparencyValue = config.transparentBgAlpha || 1
+  const backgroundColor = `rgba(33, 40, 54, ${transparencyValue})`
+  const foregroundColor = white
+  const cursorColor = '#528bff'
+  const borderColor = '#4d596b'
+  const tabBgDark = 'rgba(0,0,0,.15)'
+  const tabText = 'rgba(153,163,184)'
+  const tabTextActive = '#d5d9e2'
+  const dividerBg = borderColor
+
+  return Object.assign({}, config, {
+    foregroundColor,
+    backgroundColor,
+    borderColor,
+    cursorColor,
+    colors,
+    termCSS: `
+      ${config.termCSS || ''}
+      .cursor-node {
+        mix-blend-mode: difference;
+      }
+    `,
+    css: `
+      ${config.css || ''}
+      .tabs_list {
+        margin-left: 0;
+      }
+      .tab_tab.tab_first {
+        padding-left: 82px;
+      }
+      .tab_textInner {
+        color: ${tabText};
+      }
+      .tab_tab:not(.tab_active) {
+        background-color: ${tabBgDark};
+      }
+      .tab_tab.tab_active .tab_textInner {
+        color: ${tabTextActive};
+      }
+      .tab_tab.tab_active {
+        font-weight: 600;
+      }
+      .splitpane_divider {
+        background-color: ${dividerBg};
+      }
+    `
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-electron-highlighter",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Hyper theme based on Atom Electron Highlighter syntax",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Big changes to incorporate some of the newer features of Hyper as of 0.8.1. Here's what this includes:
1. got rid of the Atom style tabs. They were awesome, and I still ❤️ them, but they were holding us back. It added quite a big of CSS, but mainly it prevented us from adding the next feature. Maybe I'll make a separate package just for the tab styles...
2. TRANSPARENT BACKGROUND! It's still a bit finnicky - Electron and Chrome have some weirdness to making the background transparent, but overall it's fairly solid right now, so we're adding it in. Transparency is customizable. Detailed instructions are in the README, but basically there's a flag you can add to your `.hyper.js` config to pass an alpha value. If you don't have one, it defaults to 1 (i.e. no transparency).
3. Minor tweaks. Changed the border color, adjusted inactive tab background color (mostly to be compatible with transparency), moved some variables around, etc.

Overall I'm pretty happy with the changes here.
