### PR TITLE
Less prominent border color

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,11 +35,11 @@ module.exports.decorateConfig = config => {
   const backgroundColor = `rgba(33,40,54,${transparencyValue})`
   const foregroundColor = white
   const cursorColor = config.cursorColor || '#528bff'
-  const borderColor = '#4d596b'
+  const borderColor = 'rgb(64,74,89)'
   const tabBgDark = 'rgba(0,0,0,.2)'
   const tabText = 'rgba(153,163,184)'
   const tabTextActive = '#d5d9e2'
-  const dividerBg = borderColor
+  const dividerBg = 'rgba(64,74,89,.6)'
 
   return Object.assign({}, config, {
     foregroundColor,


### PR DESCRIPTION
The border color is pretty bright compared to the rest of the app and it stands out a bit much for my liking. This darkens the border color up a bit, which affects the border window and the tab borders. I also made the split pane dividers match this and faded them to 60%.