### PR TITLE
Hide title when only one tab and tweak nav styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,30 +16,6 @@ plugins: [
 ```
 3. Fully reload HyperTerm (`Cmd+Shift+R`), and tada! :tada:
 
-### Transparency
-
-So you want a transparent terminal huh? Can't say I blame you. This theme allows you to customize the background transparency by setting a value in your `~/.hyper.js` config. Just create a property called `transparentBgAlpha` in the `config` object and give it a value. This value will be passed into the background color in the theme as the `a` portion of the `rgba` (if you don't add this property, it defaults to 1, which is no transparency). So for example, if you want your terminal to have 70% alpha, this is what you'd do:
-
-```js
-// ~/.hyper.js
-
-module.exports = {
-  config = {
-    // your normal settings and stuff
-    ...
-
-    // add this one!
-    transparentBgAlpha: 0.7,
-
-    // maybe more stuff here?
-  },
-  plugins: [
-    'hyper-electron-highlighter'
-  ],
-  localPlugins: []
-}
-```
-
 ### License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -32,12 +32,11 @@ const colors = {
 module.exports.onWindow = browserWindow => browserWindow.setVibrancy('dark')
 
 module.exports.decorateConfig = config => {
-  const transparencyValue = config.transparentBgAlpha || 1
-  const backgroundColor = transparencyValue === 1 ? black : `rgba(33,40,54,${transparencyValue})`
+  const backgroundColor = black
   const foregroundColor = white
   const cursorColor = config.cursorColor || '#528bff'
   const borderColor = '#141820'
-  const inactiveTabBg = '#1b212c'
+  const tabNavBg = '#1b212c'
   const tabText = 'rgba(153,163,184,.8)'
   const tabTextActive = '#d5d9e2'
   const dividerBg = 'rgba(64,74,89,.4)'
@@ -56,9 +55,16 @@ module.exports.decorateConfig = config => {
     `,
     css: `
       ${config.css || ''}
+      .tabs_nav {
+        background-color: ${tabNavBg};
+        border-bottom: 1px solid ${borderColor};
+      }
       .tabs_list {
         margin-left: 0;
       }
+      .tabs_title {
+  			display: none !important;
+  		}
       .tab_tab.tab_first {
         padding-left: 82px;
       }
@@ -66,8 +72,8 @@ module.exports.decorateConfig = config => {
         color: ${tabText};
         font-weight: 500;
       }
-      .tab_tab:not(.tab_active) {
-        background-color: ${inactiveTabBg};
+      .tab_tab.tab_active {
+        background-color: ${backgroundColor};
       }
       .tab_tab.tab_active .tab_textInner {
         color: ${tabTextActive};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-electron-highlighter",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Hyper theme based on Atom Electron Highlighter syntax",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-electron-highlighter",
-  "version": "2.6.0",
+  "version": "2.5.0",
   "description": "Hyper theme based on Atom Electron Highlighter syntax",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
- When there is only one tab open, no need to show the title.
- Adjust nav styles for when only one tab
- Removes transparency option. It never worked quite right and the tabs never played nice with it.